### PR TITLE
Made numerator denominator private

### DIFF
--- a/PerfectDecimal/PerfectDecimal-test/ConstructorTests.cs
+++ b/PerfectDecimal/PerfectDecimal-test/ConstructorTests.cs
@@ -8,11 +8,12 @@ namespace PerfectDecimal_test
         public void EmptyConstructorCreatesOne()
         {
             PerfectDecimal subject = new();
+            PerfectDecimal test = new(0, 1);
 
             Assert.Multiple(() =>
             {
-                Assert.That(subject.Numerator, Is.EqualTo(BigInteger.Zero));
-                Assert.That(subject.Denominator, Is.EqualTo(BigInteger.One));
+                Assert.That(subject, Is.EqualTo(test));
+                Assert.That(subject, Is.EqualTo(test));
             });
         }
     }
@@ -23,11 +24,12 @@ namespace PerfectDecimal_test
         public void Positive_Numerator_Positive_Denominator_Positive_Whole()
         {
             PerfectDecimal subject = new(23, 23);
+            PerfectDecimal test = new(1, 1);
 
             Assert.Multiple(() =>
             {
-                Assert.That(subject.Numerator, Is.EqualTo(new BigInteger(23)));
-                Assert.That(subject.Denominator, Is.EqualTo(new BigInteger(23)));
+                Assert.That(subject, Is.EqualTo(test));
+                Assert.That(subject, Is.EqualTo(test));
             });
         }
 
@@ -35,11 +37,12 @@ namespace PerfectDecimal_test
         public void Positive_Numerator_Positive_Denominator_Positive_Fraction()
         {
             PerfectDecimal subject = new(1, 3);
+            PerfectDecimal test = new(2, 6);
 
             Assert.Multiple(() =>
             {
-                Assert.That(subject.Numerator, Is.EqualTo(BigInteger.One));
-                Assert.That(subject.Denominator, Is.EqualTo(new BigInteger(3)));
+                Assert.That(subject, Is.EqualTo(test));
+                Assert.That(subject, Is.EqualTo(test));
             });
         }
 
@@ -47,11 +50,12 @@ namespace PerfectDecimal_test
         public void Positive_Numerator_Negative_Denominator_Negative_Whole()
         {
             PerfectDecimal subject = new(50, -50);
+            PerfectDecimal test = new(1, -1);
 
             Assert.Multiple(() =>
             {
-                Assert.That(subject.Numerator, Is.EqualTo(new BigInteger(50)));
-                Assert.That(subject.Denominator, Is.EqualTo(new BigInteger(-50)));
+                Assert.That(subject, Is.EqualTo(test));
+                Assert.That(subject, Is.EqualTo(test));
             });
         }
 
@@ -59,11 +63,12 @@ namespace PerfectDecimal_test
         public void Positive_Numerator_Negative_Denominator_Negative_Fraction()
         {
             PerfectDecimal subject = new(3, -8);
+            PerfectDecimal test = new(6, -16);
 
             Assert.Multiple(() =>
             {
-                Assert.That(subject.Numerator, Is.EqualTo(new BigInteger(3)));
-                Assert.That(subject.Denominator, Is.EqualTo(new BigInteger(-8)));
+                Assert.That(subject, Is.EqualTo(test));
+                Assert.That(subject, Is.EqualTo(test));
             });
         }
 
@@ -71,11 +76,12 @@ namespace PerfectDecimal_test
         public void Negative_Numerator_Negative_Denominator_Positive_Whole()
         {
             PerfectDecimal subject = new(-5, -5);
+            PerfectDecimal test = new(-10, -10);
 
             Assert.Multiple(() =>
             {
-                Assert.That(subject.Numerator, Is.EqualTo(new BigInteger(-5)));
-                Assert.That(subject.Denominator, Is.EqualTo(new BigInteger(-5)));
+                Assert.That(subject, Is.EqualTo(test));
+                Assert.That(subject, Is.EqualTo(test));
             });
         }
 
@@ -83,11 +89,12 @@ namespace PerfectDecimal_test
         public void Negative_Numerator_Negative_Denominator_Positive_Fraction()
         {
             PerfectDecimal subject = new(-7, -9);
+            PerfectDecimal test = new(-14, -18);
 
             Assert.Multiple(() =>
             {
-                Assert.That(subject.Numerator, Is.EqualTo(new BigInteger(-7)));
-                Assert.That(subject.Denominator, Is.EqualTo(new BigInteger(-9)));
+                Assert.That(subject, Is.EqualTo(test));
+                Assert.That(subject, Is.EqualTo(test));
             });
         }
 
@@ -95,11 +102,12 @@ namespace PerfectDecimal_test
         public void Negative_Numerator_Positive_Denominator_Negative_Whole()
         {
             PerfectDecimal subject = new(-11, 11);
+            PerfectDecimal test = new(-1, 1);
 
             Assert.Multiple(() =>
             {
-                Assert.That(subject.Numerator, Is.EqualTo(new BigInteger(-11)));
-                Assert.That(subject.Denominator, Is.EqualTo(new BigInteger(11)));
+                Assert.That(subject, Is.EqualTo(test));
+                Assert.That(subject, Is.EqualTo(test));
             });
         }
 
@@ -107,11 +115,12 @@ namespace PerfectDecimal_test
         public void Negative_Numerator_Positive_Denominator_Negative_Fraction()
         {
             PerfectDecimal subject = new(-23, 79);
+            PerfectDecimal test = new(-46, 79 * 2);
 
             Assert.Multiple(() =>
             {
-                Assert.That(subject.Numerator, Is.EqualTo(new BigInteger(-23)));
-                Assert.That(subject.Denominator, Is.EqualTo(new BigInteger(79)));
+                Assert.That(subject, Is.EqualTo(test));
+                Assert.That(subject, Is.EqualTo(test));
             });
         }
 
@@ -131,11 +140,12 @@ namespace PerfectDecimal_test
         public void Negative_Zero_Numerator_Positive_Zero()
         {
             PerfectDecimal subject = new(-0, 97);
+            PerfectDecimal test = new(-0, 1);
 
             Assert.Multiple(() =>
             {
-                Assert.That(subject.Numerator, Is.EqualTo(BigInteger.Zero));
-                Assert.That(subject.Denominator, Is.EqualTo(new BigInteger(97)));
+                Assert.That(subject, Is.EqualTo(test));
+                Assert.That(subject, Is.EqualTo(test));
             });
         }
 
@@ -143,11 +153,12 @@ namespace PerfectDecimal_test
         public void Positive_Zero_Numerator_Positive_Zero()
         {
             PerfectDecimal subject = new(0, -63);
+            PerfectDecimal test = new(0, -1);
 
             Assert.Multiple(() =>
             {
-                Assert.That(subject.Numerator, Is.EqualTo(BigInteger.Zero));
-                Assert.That(subject.Denominator, Is.EqualTo(new BigInteger(-63)));
+                Assert.That(subject, Is.EqualTo(test));
+                Assert.That(subject, Is.EqualTo(test));
             });
         }
     }

--- a/PerfectDecimal/PerfectDecimal/PerfectDecimal.cs
+++ b/PerfectDecimal/PerfectDecimal/PerfectDecimal.cs
@@ -167,7 +167,7 @@ namespace ExtendedNumerics
                 return false;
         }
 
-        private (BigInteger leftNumerator, BigInteger rightNumerator) MakeLike(PerfectDecimal left,  PerfectDecimal right)
+        private static (BigInteger leftNumerator, BigInteger rightNumerator) MakeLike(PerfectDecimal left,  PerfectDecimal right)
         {
             BigInteger leftNumerator = left._numerator * right._denominator;
             BigInteger rightNumerator = right._numerator * left._denominator;

--- a/PerfectDecimal/PerfectDecimal/PerfectDecimal.cs
+++ b/PerfectDecimal/PerfectDecimal/PerfectDecimal.cs
@@ -65,14 +65,12 @@ namespace ExtendedNumerics
         {
             if (value is PerfectDecimal perfectDecimal)
             {
-                // make fractions like then compare
-                BigInteger myNumerator = _numerator * perfectDecimal._denominator;
-                BigInteger objNumerator = perfectDecimal._numerator * _denominator;
+                var numerators = MakeLike(this, perfectDecimal);
 
-                if (myNumerator < objNumerator)
+                if (numerators.leftNumerator < numerators.rightNumerator)
                     return -1;
 
-                else if (myNumerator == objNumerator)
+                else if (numerators.leftNumerator == numerators.rightNumerator)
                     return 0;
 
                 else
@@ -90,17 +88,15 @@ namespace ExtendedNumerics
         {
             if (value is not null)
             {
-                BigInteger myNumerator = _numerator * value._denominator;
-                BigInteger valueNumerator = value._numerator * _denominator;
+                var numerators = MakeLike(this, value);
 
-                if (myNumerator < valueNumerator)
+                if (numerators.leftNumerator < numerators.rightNumerator)
                     return -1;
 
-                else if (myNumerator == valueNumerator)
+                else if (numerators.leftNumerator == numerators.rightNumerator)
                     return 0;
 
-                else
-                    return 1;
+                else return 1;
             }
 
             else
@@ -109,44 +105,39 @@ namespace ExtendedNumerics
 
         public static bool operator <(PerfectDecimal left, PerfectDecimal right)
         {
-            BigInteger leftNumerator = left._numerator * right._denominator;
-            BigInteger rightNumerator = right._numerator * left._denominator;
+            var numerators = MakeLike(left, right);
 
-            return leftNumerator < rightNumerator;
+            return numerators.leftNumerator < numerators.rightNumerator;
         }
 
         public static bool operator >(PerfectDecimal left, PerfectDecimal right)
         {
-            BigInteger leftNumerator = left.Numerator * right.Denominator;
-            BigInteger rightNumerator = right.Numerator * left.Denominator;
+            var numerators = MakeLike(left, right);
 
-            return leftNumerator > rightNumerator;
+            return numerators.leftNumerator > numerators.rightNumerator;
         }
 
         public static bool operator <=(PerfectDecimal left, PerfectDecimal right)
         {
-            BigInteger leftNumerator = left.Numerator * right.Denominator;
-            BigInteger rightNumerator = right.Numerator * left.Denominator;
+            var numerators = MakeLike(left, right);
 
-            return leftNumerator <= rightNumerator;
+            return numerators.leftNumerator <= numerators.rightNumerator;
         }
 
         public static bool operator >=(PerfectDecimal left, PerfectDecimal right)
         {
-            BigInteger leftNumerator = left.Numerator * right.Denominator;
-            BigInteger rightNumerator = right.Numerator * left.Denominator;
+            var numerators = MakeLike(left, right);
 
-            return leftNumerator >= rightNumerator;
+            return numerators.leftNumerator >= numerators.rightNumerator;
         }
 
         public static bool operator ==(PerfectDecimal? left, PerfectDecimal? right)
         {
             if (left is not null && right is not null)
             {
-                BigInteger leftNumerator = left.Numerator * right.Denominator;
-                BigInteger rightNumerator = right.Numerator * left.Denominator;
+                var numerators = MakeLike(left, right);
 
-                return leftNumerator == rightNumerator;
+                return numerators.leftNumerator == numerators.rightNumerator;
             }
 
             else
@@ -157,10 +148,9 @@ namespace ExtendedNumerics
         {
             if (left is not null && right is not null)
             {
-                BigInteger leftNumerator = left.Numerator * right.Denominator;
-                BigInteger rightNumerator = right.Numerator * left.Denominator;
+                var numerators = MakeLike(left, right);
 
-                return leftNumerator != rightNumerator;
+                return numerators.leftNumerator != numerators.rightNumerator;
             }
 
             else

--- a/PerfectDecimal/PerfectDecimal/PerfectDecimal.cs
+++ b/PerfectDecimal/PerfectDecimal/PerfectDecimal.cs
@@ -65,12 +65,12 @@ namespace ExtendedNumerics
         {
             if (value is PerfectDecimal perfectDecimal)
             {
-                var numerators = MakeLike(this, perfectDecimal);
+                var (leftNumerator, rightNumerator) = MakeLike(this, perfectDecimal);
 
-                if (numerators.leftNumerator < numerators.rightNumerator)
+                if (leftNumerator < rightNumerator)
                     return -1;
 
-                else if (numerators.leftNumerator == numerators.rightNumerator)
+                else if (leftNumerator == rightNumerator)
                     return 0;
 
                 else
@@ -88,12 +88,12 @@ namespace ExtendedNumerics
         {
             if (value is not null)
             {
-                var numerators = MakeLike(this, value);
+                var (leftNumerator, rightNumerator) = MakeLike(this, value);
 
-                if (numerators.leftNumerator < numerators.rightNumerator)
+                if (leftNumerator < rightNumerator)
                     return -1;
 
-                else if (numerators.leftNumerator == numerators.rightNumerator)
+                else if (leftNumerator == rightNumerator)
                     return 0;
 
                 else return 1;
@@ -105,39 +105,39 @@ namespace ExtendedNumerics
 
         public static bool operator <(PerfectDecimal left, PerfectDecimal right)
         {
-            var numerators = MakeLike(left, right);
+            var (leftNumerator, rightNumerator) = MakeLike(left, right);
 
-            return numerators.leftNumerator < numerators.rightNumerator;
+            return leftNumerator < rightNumerator;
         }
 
         public static bool operator >(PerfectDecimal left, PerfectDecimal right)
         {
-            var numerators = MakeLike(left, right);
+            var (leftNumerator, rightNumerator) = MakeLike(left, right);
 
-            return numerators.leftNumerator > numerators.rightNumerator;
+            return leftNumerator > rightNumerator;
         }
 
         public static bool operator <=(PerfectDecimal left, PerfectDecimal right)
         {
-            var numerators = MakeLike(left, right);
+            var (leftNumerator, rightNumerator) = MakeLike(left, right);
 
-            return numerators.leftNumerator <= numerators.rightNumerator;
+            return leftNumerator <= rightNumerator;
         }
 
         public static bool operator >=(PerfectDecimal left, PerfectDecimal right)
         {
-            var numerators = MakeLike(left, right);
+            var (leftNumerator, rightNumerator) = MakeLike(left, right);
 
-            return numerators.leftNumerator >= numerators.rightNumerator;
+            return leftNumerator >= rightNumerator;
         }
 
         public static bool operator ==(PerfectDecimal? left, PerfectDecimal? right)
         {
             if (left is not null && right is not null)
             {
-                var numerators = MakeLike(left, right);
+                var (leftNumerator, rightNumerator) = MakeLike(left, right);
 
-                return numerators.leftNumerator == numerators.rightNumerator;
+                return leftNumerator == rightNumerator;
             }
 
             else
@@ -148,9 +148,9 @@ namespace ExtendedNumerics
         {
             if (left is not null && right is not null)
             {
-                var numerators = MakeLike(left, right);
+                var (leftNumerator, rightNumerator) = MakeLike(left, right);
 
-                return numerators.leftNumerator != numerators.rightNumerator;
+                return leftNumerator != rightNumerator;
             }
 
             else

--- a/PerfectDecimal/PerfectDecimal/PerfectDecimal.cs
+++ b/PerfectDecimal/PerfectDecimal/PerfectDecimal.cs
@@ -11,9 +11,6 @@ namespace ExtendedNumerics
         private BigInteger _numerator;
         private BigInteger _denominator;
 
-        public BigInteger Numerator { get => _numerator; }
-        public BigInteger Denominator { get => _denominator; }
-
         public PerfectDecimal()
         {
             _numerator = BigInteger.Zero;
@@ -69,8 +66,8 @@ namespace ExtendedNumerics
             if (value is PerfectDecimal perfectDecimal)
             {
                 // make fractions like then compare
-                BigInteger myNumerator = _numerator * perfectDecimal.Denominator;
-                BigInteger objNumerator = perfectDecimal.Numerator * _denominator;
+                BigInteger myNumerator = _numerator * perfectDecimal._denominator;
+                BigInteger objNumerator = perfectDecimal._numerator * _denominator;
 
                 if (myNumerator < objNumerator)
                     return -1;
@@ -93,8 +90,8 @@ namespace ExtendedNumerics
         {
             if (value is not null)
             {
-                BigInteger myNumerator = _numerator * value.Denominator;
-                BigInteger valueNumerator = value.Numerator * _denominator;
+                BigInteger myNumerator = _numerator * value._denominator;
+                BigInteger valueNumerator = value._numerator * _denominator;
 
                 if (myNumerator < valueNumerator)
                     return -1;
@@ -112,8 +109,8 @@ namespace ExtendedNumerics
 
         public static bool operator <(PerfectDecimal left, PerfectDecimal right)
         {
-            BigInteger leftNumerator = left.Numerator * right.Denominator;
-            BigInteger rightNumerator = right.Numerator * left.Denominator;
+            BigInteger leftNumerator = left._numerator * right._denominator;
+            BigInteger rightNumerator = right._numerator * left._denominator;
 
             return leftNumerator < rightNumerator;
         }
@@ -168,6 +165,14 @@ namespace ExtendedNumerics
 
             else
                 return false;
+        }
+
+        private (BigInteger leftNumerator, BigInteger rightNumerator) MakeLike(PerfectDecimal left,  PerfectDecimal right)
+        {
+            BigInteger leftNumerator = left._numerator * right._denominator;
+            BigInteger rightNumerator = right._numerator * left._denominator;
+
+            return (leftNumerator, rightNumerator);
         }
     }
 }

--- a/PerfectDecimal/PerfectDecimal/PerfectDecimal.cs
+++ b/PerfectDecimal/PerfectDecimal/PerfectDecimal.cs
@@ -106,28 +106,24 @@ namespace ExtendedNumerics
         public static bool operator <(PerfectDecimal left, PerfectDecimal right)
         {
             var (leftNumerator, rightNumerator) = MakeLike(left, right);
-
             return leftNumerator < rightNumerator;
         }
 
         public static bool operator >(PerfectDecimal left, PerfectDecimal right)
         {
             var (leftNumerator, rightNumerator) = MakeLike(left, right);
-
             return leftNumerator > rightNumerator;
         }
 
         public static bool operator <=(PerfectDecimal left, PerfectDecimal right)
         {
             var (leftNumerator, rightNumerator) = MakeLike(left, right);
-
             return leftNumerator <= rightNumerator;
         }
 
         public static bool operator >=(PerfectDecimal left, PerfectDecimal right)
         {
             var (leftNumerator, rightNumerator) = MakeLike(left, right);
-
             return leftNumerator >= rightNumerator;
         }
 
@@ -136,7 +132,6 @@ namespace ExtendedNumerics
             if (left is not null && right is not null)
             {
                 var (leftNumerator, rightNumerator) = MakeLike(left, right);
-
                 return leftNumerator == rightNumerator;
             }
 
@@ -149,7 +144,6 @@ namespace ExtendedNumerics
             if (left is not null && right is not null)
             {
                 var (leftNumerator, rightNumerator) = MakeLike(left, right);
-
                 return leftNumerator != rightNumerator;
             }
 


### PR DESCRIPTION
This solves issue https://github.com/jacob-bauer/PerfectDecimal/issues/33 by removing the public `Numerator` and `Denominator` properties, and updates all methods and tests to reflect that change.

Also introduces a new method `MakeLike(PerfectDecimal, PerfectDecimal)` that takes two possibly unlike fractions and returns them as like fractions.