### PR TITLE
Fixed methods for failing tests

### DIFF
--- a/PerfectDecimal/PerfectDecimal-test/ComparisonTests.cs
+++ b/PerfectDecimal/PerfectDecimal-test/ComparisonTests.cs
@@ -85,7 +85,7 @@ namespace PerfectDecimal_test
         [Test]
         public void Negative_Denominator_Less_Than_Negative()
         {
-            PerfectDecimal subject = new(408, -504);
+            PerfectDecimal subject = new(400, -504);
             PerfectDecimal test = new(-400, 600);
 
             Assert.That(subject <= test, Is.True);

--- a/PerfectDecimal/PerfectDecimal-test/ComparisonTests.cs
+++ b/PerfectDecimal/PerfectDecimal-test/ComparisonTests.cs
@@ -215,7 +215,7 @@ namespace PerfectDecimal_test
         public void Negative_Denominator_Greater_Than_Negative()
         {
             PerfectDecimal subject = new(1, -8);
-            PerfectDecimal test = new(-1, 7054);
+            PerfectDecimal test = new(-1, 6);
 
             Assert.That(subject >= test, Is.True);
         }

--- a/PerfectDecimal/PerfectDecimal-test/ComparisonTests.cs
+++ b/PerfectDecimal/PerfectDecimal-test/ComparisonTests.cs
@@ -223,8 +223,8 @@ namespace PerfectDecimal_test
         [Test]
         public void Negative_Both_Greater_Than_Negative_Both()
         {
-            PerfectDecimal subject = new(-1, -3);
-            PerfectDecimal test = new(-9, -8);
+            PerfectDecimal subject = new(-9, -8);
+            PerfectDecimal test = new(-1, -3);
 
             Assert.That(subject >= test, Is.True);
         }

--- a/PerfectDecimal/PerfectDecimal-test/ComparisonTests.cs
+++ b/PerfectDecimal/PerfectDecimal-test/ComparisonTests.cs
@@ -400,8 +400,8 @@ namespace PerfectDecimal_test
         [Test]
         public void Negative_Both_Less_Than_Negative_Both()
         {
-            PerfectDecimal subject = new(-1, -2);
-            PerfectDecimal test = new(-1, -4);
+            PerfectDecimal subject = new(-1, -4);
+            PerfectDecimal test = new(-1, -2);
 
             Assert.That(subject < test, Is.True);
         }

--- a/PerfectDecimal/PerfectDecimal-test/ComparisonTests.cs
+++ b/PerfectDecimal/PerfectDecimal-test/ComparisonTests.cs
@@ -94,8 +94,8 @@ namespace PerfectDecimal_test
         [Test]
         public void Negative_Both_Less_Than_Negative_Both()
         {
-            PerfectDecimal subject = new(-1, -2);
-            PerfectDecimal test = new(-1, -6);
+            PerfectDecimal subject = new(-1, -6);
+            PerfectDecimal test = new(-1, -2);
 
             Assert.That(subject <= test, Is.True);
         }

--- a/PerfectDecimal/PerfectDecimal/PerfectDecimal.cs
+++ b/PerfectDecimal/PerfectDecimal/PerfectDecimal.cs
@@ -105,93 +105,25 @@ namespace ExtendedNumerics
 
         public static bool operator <(PerfectDecimal left, PerfectDecimal right)
         {
-            BigInteger leftNumerator = left._numerator;
-            BigInteger rightNumerator = right._numerator;
-            BigInteger leftDenominator = left._denominator;
-            BigInteger rightDenominator = right._denominator;
-
-            if (leftDenominator.Sign == -1)
-            {
-                leftNumerator = -leftNumerator;
-                leftDenominator = -leftDenominator;
-            }
-
-            if (rightDenominator.Sign == -1)
-            {
-                rightNumerator = -rightNumerator;
-                rightDenominator = -rightDenominator;
-
-            }
-
+            var (leftNumerator, rightNumerator, leftDenominator, rightDenominator) = MassageFractionSigns(left, right);
             return (leftNumerator * rightDenominator) < (rightNumerator * leftDenominator);
         }
 
         public static bool operator >(PerfectDecimal left, PerfectDecimal right)
         {
-            BigInteger leftNumerator = left._numerator;
-            BigInteger rightNumerator = right._numerator;
-            BigInteger leftDenominator = left._denominator;
-            BigInteger rightDenominator = right._denominator;
-
-            if (leftDenominator.Sign == -1)
-            {
-                leftNumerator = -leftNumerator;
-                leftDenominator = -leftDenominator;
-            }
-
-            if (rightDenominator.Sign == -1)
-            {
-                rightNumerator = -rightNumerator;
-                rightDenominator = -rightDenominator;
-
-            }
-
+            var (leftNumerator, rightNumerator, leftDenominator, rightDenominator) = MassageFractionSigns(left, right);
             return (leftNumerator * rightDenominator) > (rightNumerator * leftDenominator);
         }
 
         public static bool operator <=(PerfectDecimal left, PerfectDecimal right)
         {
-            BigInteger leftNumerator = left._numerator;
-            BigInteger rightNumerator = right._numerator;
-            BigInteger leftDenominator = left._denominator;
-            BigInteger rightDenominator = right._denominator;
-
-            if (leftDenominator.Sign == -1)
-            {
-                leftNumerator = -leftNumerator;
-                leftDenominator = -leftDenominator;
-            }
-
-            if (rightDenominator.Sign == -1)
-            {
-                rightNumerator = -rightNumerator;
-                rightDenominator = -rightDenominator;
-
-            }
-
+            var (leftNumerator, rightNumerator, leftDenominator, rightDenominator) = MassageFractionSigns(left, right);
             return (leftNumerator * rightDenominator) <= (rightNumerator * leftDenominator);
         }
 
         public static bool operator >=(PerfectDecimal left, PerfectDecimal right)
         {
-            BigInteger leftNumerator = left._numerator;
-            BigInteger rightNumerator = right._numerator;
-            BigInteger leftDenominator = left._denominator;
-            BigInteger rightDenominator = right._denominator;
-
-            if (leftDenominator.Sign == -1)
-            {
-                leftNumerator = -leftNumerator;
-                leftDenominator = -leftDenominator;
-            }
-
-            if (rightDenominator.Sign == -1)
-            {
-                rightNumerator = -rightNumerator;
-                rightDenominator = -rightDenominator;
-
-            }
-
+            var (leftNumerator, rightNumerator, leftDenominator, rightDenominator) = MassageFractionSigns(left, right);
             return (leftNumerator * rightDenominator) >= (rightNumerator * leftDenominator);
         }
 

--- a/PerfectDecimal/PerfectDecimal/PerfectDecimal.cs
+++ b/PerfectDecimal/PerfectDecimal/PerfectDecimal.cs
@@ -174,8 +174,25 @@ namespace ExtendedNumerics
 
         public static bool operator >=(PerfectDecimal left, PerfectDecimal right)
         {
-            var (leftNumerator, rightNumerator) = MakeLike(left, right);
-            return leftNumerator >= rightNumerator;
+            BigInteger leftNumerator = left._numerator;
+            BigInteger rightNumerator = right._numerator;
+            BigInteger leftDenominator = left._denominator;
+            BigInteger rightDenominator = right._denominator;
+
+            if (leftDenominator.Sign == -1)
+            {
+                leftNumerator = -leftNumerator;
+                leftDenominator = -leftDenominator;
+            }
+
+            if (rightDenominator.Sign == -1)
+            {
+                rightNumerator = -rightNumerator;
+                rightDenominator = -rightDenominator;
+
+            }
+
+            return (leftNumerator * rightDenominator) >= (rightNumerator * leftDenominator);
         }
 
         public static bool operator ==(PerfectDecimal? left, PerfectDecimal? right)

--- a/PerfectDecimal/PerfectDecimal/PerfectDecimal.cs
+++ b/PerfectDecimal/PerfectDecimal/PerfectDecimal.cs
@@ -151,8 +151,25 @@ namespace ExtendedNumerics
 
         public static bool operator <=(PerfectDecimal left, PerfectDecimal right)
         {
-            var (leftNumerator, rightNumerator) = MakeLike(left, right);
-            return leftNumerator <= rightNumerator;
+            BigInteger leftNumerator = left._numerator;
+            BigInteger rightNumerator = right._numerator;
+            BigInteger leftDenominator = left._denominator;
+            BigInteger rightDenominator = right._denominator;
+
+            if (leftDenominator.Sign == -1)
+            {
+                leftNumerator = -leftNumerator;
+                leftDenominator = -leftDenominator;
+            }
+
+            if (rightDenominator.Sign == -1)
+            {
+                rightNumerator = -rightNumerator;
+                rightDenominator = -rightDenominator;
+
+            }
+
+            return (leftNumerator * rightDenominator) <= (rightNumerator * leftDenominator);
         }
 
         public static bool operator >=(PerfectDecimal left, PerfectDecimal right)

--- a/PerfectDecimal/PerfectDecimal/PerfectDecimal.cs
+++ b/PerfectDecimal/PerfectDecimal/PerfectDecimal.cs
@@ -107,6 +107,27 @@ namespace ExtendedNumerics
         {
             var (leftNumerator, rightNumerator) = MakeLike(left, right);
             return leftNumerator < rightNumerator;
+
+            // These changes need to take place before the call to make like
+            BigInteger leftNumerator = left._numerator;
+            BigInteger rightNumerator = right._numerator;
+            BigInteger leftDenominator = left._denominator;
+            BigInteger rightDenominator = right._denominator;
+
+            if (leftDenominator.Sign == -1)
+            {
+                leftNumerator = -leftNumerator;
+                leftDenominator = -leftDenominator;
+            }
+
+            if (rightDenominator.Sign == -1)
+            {
+                rightNumerator = -rightNumerator;
+                rightDenominator = -rightDenominator;
+
+            }
+
+            return (leftNumerator * rightDenominator) < (rightNumerator * leftDenominator);
         }
 
         public static bool operator >(PerfectDecimal left, PerfectDecimal right)

--- a/PerfectDecimal/PerfectDecimal/PerfectDecimal.cs
+++ b/PerfectDecimal/PerfectDecimal/PerfectDecimal.cs
@@ -223,5 +223,27 @@ namespace ExtendedNumerics
         {
             return (left._numerator * right._denominator, right._numerator * left._denominator);
         }
+
+        private static (BigInteger leftNumerator, BigInteger rightNumerator, BigInteger leftDenominator, BigInteger rightDenominator) MassageFractionSigns(PerfectDecimal left, PerfectDecimal right)
+        {
+            BigInteger leftNumerator = left._numerator;
+            BigInteger rightNumerator = right._numerator;
+            BigInteger leftDenominator = left._denominator;
+            BigInteger rightDenominator = right._denominator;
+
+            if (leftDenominator.Sign == -1)
+            {
+                leftNumerator = -leftNumerator;
+                leftDenominator = -leftDenominator;
+            }
+
+            if (rightDenominator.Sign == -1)
+            {
+                rightNumerator = -rightNumerator;
+                rightDenominator = -rightDenominator;
+            }
+
+            return (leftNumerator, rightNumerator, leftDenominator, rightDenominator);
+        }
     }
 }

--- a/PerfectDecimal/PerfectDecimal/PerfectDecimal.cs
+++ b/PerfectDecimal/PerfectDecimal/PerfectDecimal.cs
@@ -105,10 +105,6 @@ namespace ExtendedNumerics
 
         public static bool operator <(PerfectDecimal left, PerfectDecimal right)
         {
-            var (leftNumerator, rightNumerator) = MakeLike(left, right);
-            return leftNumerator < rightNumerator;
-
-            // These changes need to take place before the call to make like
             BigInteger leftNumerator = left._numerator;
             BigInteger rightNumerator = right._numerator;
             BigInteger leftDenominator = left._denominator;

--- a/PerfectDecimal/PerfectDecimal/PerfectDecimal.cs
+++ b/PerfectDecimal/PerfectDecimal/PerfectDecimal.cs
@@ -128,8 +128,25 @@ namespace ExtendedNumerics
 
         public static bool operator >(PerfectDecimal left, PerfectDecimal right)
         {
-            var (leftNumerator, rightNumerator) = MakeLike(left, right);
-            return leftNumerator > rightNumerator;
+            BigInteger leftNumerator = left._numerator;
+            BigInteger rightNumerator = right._numerator;
+            BigInteger leftDenominator = left._denominator;
+            BigInteger rightDenominator = right._denominator;
+
+            if (leftDenominator.Sign == -1)
+            {
+                leftNumerator = -leftNumerator;
+                leftDenominator = -leftDenominator;
+            }
+
+            if (rightDenominator.Sign == -1)
+            {
+                rightNumerator = -rightNumerator;
+                rightDenominator = -rightDenominator;
+
+            }
+
+            return (leftNumerator * rightDenominator) > (rightNumerator * leftDenominator);
         }
 
         public static bool operator <=(PerfectDecimal left, PerfectDecimal right)


### PR DESCRIPTION
Some tests were implemented badly, in a way were the conditions could never be correct.

Other times, the comparison operators had trouble dealing with negative denominators. This was corrected by introducing a new method which massages the denominators to roll a negative denominator into a negative numerator, or make both positive if both are negative.

This solves issue https://github.com/jacob-bauer/PerfectDecimal/issues/40