### PR TITLE
Prettify things

### DIFF
--- a/PerfectDecimal/PerfectDecimal-test/ComparisonTests.cs
+++ b/PerfectDecimal/PerfectDecimal-test/ComparisonTests.cs
@@ -250,7 +250,7 @@ namespace PerfectDecimal_test
         [Test]
         public void Positive_Greater_Than_Zero()
         {
-            PerfectDecimal subject = new PerfectDecimal(1, 1000000);
+            PerfectDecimal subject = new(1, 1000000);
             PerfectDecimal test = new();
 
             Assert.That(subject >= test, Is.True);
@@ -418,7 +418,7 @@ namespace PerfectDecimal_test
         [Test]
         public void Negative_Less_Than_Zero()
         {
-            PerfectDecimal subject = new PerfectDecimal(-1, 2);
+            PerfectDecimal subject = new(-1, 2);
             PerfectDecimal test = new();
 
             Assert.That(subject < test, Is.True);

--- a/PerfectDecimal/PerfectDecimal-test/ComparisonTests.cs
+++ b/PerfectDecimal/PerfectDecimal-test/ComparisonTests.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 
 namespace PerfectDecimal_test
 {
+    // Cannot use ComparisonConstraint since it just calls the IEquatable interface and I need to actually call the comparison operators.
+#pragma warning disable NUnit2043 // Use ComparisonConstraint for better assertion messages in case of failure
     internal class LessThanOrEqualTests()
     {
         [Test]
@@ -16,7 +18,9 @@ namespace PerfectDecimal_test
             PerfectDecimal subject = new(-3, -6);
             PerfectDecimal test = new(-6, -12);
 
+
             Assert.That(subject <= test, Is.True);
+
         }
 
         [Test]
@@ -433,6 +437,7 @@ namespace PerfectDecimal_test
             Assert.That(subject < test, Is.False);
         }
     }
+#pragma warning restore NUnit2043 // Use ComparisonConstraint for better assertion messages in case of failure
 
     internal class IComparableOfTTests
     {

--- a/PerfectDecimal/PerfectDecimal/PerfectDecimal.cs
+++ b/PerfectDecimal/PerfectDecimal/PerfectDecimal.cs
@@ -36,15 +36,9 @@ namespace ExtendedNumerics
             }
         }
 
-        public override bool Equals(object? value)
-        {
-            return value is PerfectDecimal other && CompareTo(other) == 0;
-        }
+        public override bool Equals(object? value) => value is PerfectDecimal other && CompareTo(other) == 0;
 
-        public bool Equals(PerfectDecimal? value)
-        {
-            return value is PerfectDecimal other && CompareTo(other) == 0;
-        }
+        public bool Equals(PerfectDecimal? value) => value is PerfectDecimal other && CompareTo(other) == 0;
 
         public override int GetHashCode()
         {
@@ -151,10 +145,7 @@ namespace ExtendedNumerics
                 return false;
         }
 
-        private static (BigInteger leftNumerator, BigInteger rightNumerator) MakeLike(PerfectDecimal left,  PerfectDecimal right)
-        {
-            return (left._numerator * right._denominator, right._numerator * left._denominator);
-        }
+        private static (BigInteger leftNumerator, BigInteger rightNumerator) MakeLike(PerfectDecimal left,  PerfectDecimal right) => (left._numerator * right._denominator, right._numerator * left._denominator);
 
         private static (BigInteger leftNumerator, BigInteger rightNumerator, BigInteger leftDenominator, BigInteger rightDenominator) MassageFractionSigns(PerfectDecimal left, PerfectDecimal right)
         {


### PR DESCRIPTION
This just fixes some formatting errors and suppresses some warnings about using a new assertion model, which can't be used for testing comparison operators because it bypasses them and calls the `IEquatable` interface.